### PR TITLE
Update for Pimcore v11

### DIFF
--- a/PolargoldIFramePortletBundle.php
+++ b/PolargoldIFramePortletBundle.php
@@ -3,9 +3,15 @@
 namespace Polargold\PolargoldIFramePortletBundle;
 
 use Pimcore\Extension\Bundle\AbstractPimcoreBundle;
+use Pimcore\Extension\Bundle\PimcoreBundleAdminClassicInterface;
+use Pimcore\Extension\Bundle\Traits\BundleAdminClassicTrait;
+use Pimcore\Extension\Bundle\Traits\PackageVersionTrait;
 
-class PolargoldIFramePortletBundle extends AbstractPimcoreBundle
+class PolargoldIFramePortletBundle extends AbstractPimcoreBundle implements PimcoreBundleAdminClassicInterface
 {
+    use BundleAdminClassicTrait;
+    use PackageVersionTrait;
+
     /**
      * @return string[]
      * @noinspection SpellCheckingInspection


### PR DESCRIPTION
At least on version of Pimcore, 11.2.4 (2024.1), there are some additional things needed in order for assets to load properly. The `PackageVersionTrait` isn't necessarily needed and the assets load fine without it, but it is included in the structure you can see here:

https://pimcore.com/docs/platform/Pimcore/Extending_Pimcore/Bundle_Developers_Guide/Loading_Admin_UI_Assets/#encore

Using this PR as is, I can confirm the iframe portlets load into Pimcore again. Without these changes, the assets are not loaded into the latest version (11.2.4) of Pimcore.